### PR TITLE
Fixes deprecation warning in Node 8

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ var injectScript = require('html-inject-script');
 var destroyable = require('server-destroy');
 var extend = require('xtend')
 
-try {
-  fs.stat(__dirname + '/static/reporter.js')
-} catch (_) {
-  console.error('Reporter script missing. Run `make build` first.')
-}
+fs.stat(__dirname + '/static/reporter.js', function (err) {
+  if (err) {
+    console.error('Reporter script missing. Run `make build` first.')
+  }
+})
 
 module.exports = function (opts) {
   if (!opts) opts = {};


### PR DESCRIPTION
Unfortunately, Node code has decided that a stable module needs busy work
and have deprecated the use of synchronous APIs without supplying callbacks.

I wasn't sure if you wanted to do this with an async call or if it should
keep the try/catch and use the statSync method.